### PR TITLE
Remove trailing newline from access token

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -18,7 +18,7 @@ def login():
     global access_token
     if not access_token:
         with open('.credentials', 'r', encoding='utf-8') as cred:
-            access_token = cred.readline()
+            access_token = cred.readline().strip()  # <-- Remove trailing newline
             cred.close
     return access_token
 


### PR DESCRIPTION
Strip trailing newline from access token read from credentials file. Python 3.14 does not take kindly to the trailing newline:

ValueError: Invalid header value b'Bearer eyJhbGci[...]zTg\n'